### PR TITLE
Fix: exception should refer to 'button' instead of 'image'

### DIFF
--- a/src/Inputs/Button.php
+++ b/src/Inputs/Button.php
@@ -73,7 +73,7 @@ class Button extends InputElement
         }
 
         if (empty($this->value)) {
-            throw new Exception('Image must contain "value"');
+            throw new Exception('Button must contain "value"');
         }
 
         $this->text->validate();


### PR DESCRIPTION
Just fixing a small issue with an exception message.