### PR TITLE
implement Radio Buttons and Checkboxes

### DIFF
--- a/src/Blocks/Actions.php
+++ b/src/Blocks/Actions.php
@@ -78,6 +78,22 @@ class Actions extends BlockElement
         return $action;
     }
 
+    public function newRadioButtons(?string $actionId = null): Inputs\RadioButtons
+    {
+        $action = new Inputs\RadioButtons($actionId);
+        $this->add($action);
+
+        return $action;
+    }
+
+    public function newCheckboxes(?string $actionId = null): Inputs\Checkboxes
+    {
+        $action = new Inputs\Checkboxes($actionId);
+        $this->add($action);
+
+        return $action;
+    }
+
     public function validate(): void
     {
         if (empty($this->elements)) {

--- a/src/Blocks/Input.php
+++ b/src/Blocks/Input.php
@@ -116,6 +116,22 @@ class Input extends BlockElement
         return $action;
     }
 
+    public function newRadioButtons(?string $actionId = null): Inputs\RadioButtons
+    {
+        $action = new Inputs\RadioButtons($actionId);
+        $this->setElement($action);
+
+        return $action;
+    }
+
+    public function newCheckboxes(?string $actionId = null): Inputs\Checkboxes
+    {
+        $action = new Inputs\Checkboxes($actionId);
+        $this->setElement($action);
+
+        return $action;
+    }
+
     public function validate(): void
     {
         if (empty($this->label)) {

--- a/src/Blocks/Section.php
+++ b/src/Blocks/Section.php
@@ -170,6 +170,22 @@ class Section extends BlockElement
         return $action;
     }
 
+    public function newRadioButtonsAccessory(?string $actionId = null): Inputs\RadioButtons
+    {
+        $action = new Inputs\RadioButtons($actionId);
+        $this->setAccessory($action);
+
+        return $action;
+    }
+
+    public function newCheckboxesAccessory(?string $actionId = null): Inputs\Checkboxes
+    {
+        $action = new Inputs\Checkboxes($actionId);
+        $this->setAccessory($action);
+
+        return $action;
+    }
+
     public function validate(): void
     {
         if (empty($this->text) && empty($this->fields)) {

--- a/src/Inputs/Checkboxes.php
+++ b/src/Inputs/Checkboxes.php
@@ -10,7 +10,6 @@ use Jeremeamia\Slack\BlockKit\Partials\Option;
 
 class Checkboxes extends InputElement
 {
-
     use HasConfirm;
     use HasOptions;
 
@@ -33,7 +32,6 @@ class Checkboxes extends InputElement
         if (count($this->options) < self::MIN_OPTIONS) {
             throw new Exception('Option Size must be at least %d', [self::MIN_OPTIONS]);
         }
-
     }
 
     /**
@@ -56,6 +54,5 @@ class Checkboxes extends InputElement
         }
 
         return $data;
-
     }
 }

--- a/src/Inputs/Checkboxes.php
+++ b/src/Inputs/Checkboxes.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jeremeamia\Slack\BlockKit\Inputs;
+
+use Jeremeamia\Slack\BlockKit\Exception;
+use Jeremeamia\Slack\BlockKit\Partials\Option;
+
+class Checkboxes extends InputElement
+{
+
+    use HasConfirm;
+
+    private const MIN_OPTIONS = 1;
+    private const MAX_OPTIONS = 10;
+
+    /** @var array|Option[] */
+    private $options = [];
+
+    /** @var array|Option[] */
+    private $initialOptions = [];
+
+    public function addOption(Option $option, bool $isInitial = false): Checkboxes {
+
+        $this->options[] = $option;
+
+        if ($isInitial) {
+            $this->initialOptions[] = $option;
+        }
+
+        return $this;
+
+    }
+
+    public function validate(): void
+    {
+
+        if (count($this->options) > self::MAX_OPTIONS) {
+            throw new Exception('Option Size cannot exceed %d', [self::MAX_OPTIONS]);
+        }
+
+        if (count($this->options) < self::MIN_OPTIONS) {
+            throw new Exception('Option Size must be at least %d', [self::MIN_OPTIONS]);
+        }
+
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+
+        if (! empty($this->initialOptions)) {
+            $data['initial_options'] = $this->initialOptions;
+        }
+
+        $data['options'] = $this->options;
+
+        if (!empty($this->confirm)) {
+            $data['confirm'] = $this->confirm->toArray();
+        }
+
+        return $data;
+
+    }
+}

--- a/src/Inputs/RadioButtons.php
+++ b/src/Inputs/RadioButtons.php
@@ -10,7 +10,6 @@ use Jeremeamia\Slack\BlockKit\Partials\Option;
 
 class RadioButtons extends InputElement
 {
-
     use HasConfirm;
     use HasOptions;
 
@@ -25,12 +24,10 @@ class RadioButtons extends InputElement
         $hasInitial = false;
 
         foreach ($this->options as $option) {
-
             $option->validate();
 
             if ($option->isInitial()) {
-
-                if ($hasInitial)  {
+                if ($hasInitial) {
                     throw new Exception('Only one initial Option is allowed for Radio Buttons');
                 }
                 $hasInitial = true;
@@ -48,7 +45,6 @@ class RadioButtons extends InputElement
         if (count($this->options) < self::MIN_OPTIONS) {
             throw new Exception('Option Size must be at least %d', [self::MIN_OPTIONS]);
         }
-
     }
 
     /**
@@ -72,6 +68,5 @@ class RadioButtons extends InputElement
         }
 
         return $data;
-
     }
 }

--- a/src/Inputs/RadioButtons.php
+++ b/src/Inputs/RadioButtons.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jeremeamia\Slack\BlockKit\Inputs;
+
+use Jeremeamia\Slack\BlockKit\Exception;
+use Jeremeamia\Slack\BlockKit\Partials\Option;
+
+class RadioButtons extends InputElement
+{
+
+    use HasConfirm;
+
+    private const MIN_OPTIONS = 1;
+    private const MAX_OPTIONS = 10;
+
+    /** @var array|Option[] */
+    private $options = [];
+
+    /** @var Option|null */
+    private $initialOption = null;
+
+    public function addOption(Option $option, bool $isInitial = false): RadioButtons {
+
+        $this->options[] = $option;
+
+        if ($isInitial) {
+            $this->initialOption = $option;
+        }
+
+        return $this;
+
+    }
+
+    public function validate(): void
+    {
+
+        if (count($this->options) > self::MAX_OPTIONS) {
+            throw new Exception('Option Size cannot exceed %d', [self::MAX_OPTIONS]);
+        }
+
+        if (count($this->options) < self::MIN_OPTIONS) {
+            throw new Exception('Option Size must be at least %d', [self::MIN_OPTIONS]);
+        }
+
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+
+        if (! empty($this->initialOption)) {
+            $data['initial_option'] = $this->initialOption;
+        }
+
+        $data['options'] = $this->options;
+
+        if (!empty($this->confirm)) {
+            $data['confirm'] = $this->confirm->toArray();
+        }
+
+        return $data;
+
+    }
+}

--- a/src/Partials/HasOptions.php
+++ b/src/Partials/HasOptions.php
@@ -27,11 +27,12 @@ trait HasOptions
     /**
      * @param string $text
      * @param string $value
+     * @param bool $isInitial
      * @return static
      */
-    public function option(string $text, string $value): self
+    public function option(string $text, string $value, bool $isInitial = false): self
     {
-        $option = new Option($text, $value);
+        $option = new Option($text, $value, $isInitial);
         $option->setParent($this);
         $this->options[] = $option;
 

--- a/src/Partials/Option.php
+++ b/src/Partials/Option.php
@@ -61,7 +61,7 @@ class Option extends Element
     /**
      * @return bool
      */
-    public function  isInitial(): bool
+    public function isInitial(): bool
     {
         return $this->isInitial;
     }

--- a/src/Partials/Option.php
+++ b/src/Partials/Option.php
@@ -14,13 +14,17 @@ class Option extends Element
     /** @var string */
     private $value;
 
-    public function __construct(?string $text = null, string $value)
+    /** @var bool */
+    private $isInitial = false;
+
+    public function __construct(?string $text = null, string $value, bool $isInitial = false)
     {
         if ($text !== null) {
             $this->text($text);
         }
 
         $this->value($value);
+        $this->isInitial = $isInitial;
     }
 
     /**
@@ -52,6 +56,14 @@ class Option extends Element
         $this->value = $value;
 
         return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function  isInitial(): bool
+    {
+        return $this->isInitial;
     }
 
     public function validate(): void

--- a/src/Type.php
+++ b/src/Type.php
@@ -151,10 +151,10 @@ abstract class Type
 
         // Inputs
         Inputs\Button::class          => self::BUTTON,
-        Inputs\Checkboxes::class   => self::CHECKBOXES, // Not yet supported.
+        Inputs\Checkboxes::class      => self::CHECKBOXES, // Not yet supported.
         Inputs\DatePicker::class      => self::DATEPICKER,
         // Inputs\OverflowMenu::class => self::OVERFLOW_MENU, // Not yet supported.
-        Inputs\RadioButtons::class => self::RADIO_BUTTONS,
+        Inputs\RadioButtons::class    => self::RADIO_BUTTONS,
         Inputs\TextInput::class       => self::TEXT_INPUT,
 
         // Select Menus

--- a/src/Type.php
+++ b/src/Type.php
@@ -24,11 +24,11 @@ abstract class Type
 
     // Inputs
     public const BUTTON            = 'button';
-    // public const CHECKBOXES     = 'checkboxes'; // Not yet supported.
+    public const CHECKBOXES        = 'checkboxes';
     public const DATEPICKER        = 'datepicker';
     public const TEXT_INPUT        = 'plain_text_input';
     // public const OVERFLOW_MENU  = 'overflow'; // Not yet supported.
-    // public const RADIO_BUTTONS  = 'radio_buttons'; // Not yet supported.
+    public const RADIO_BUTTONS  = 'radio_buttons';
 
     // Select Menus
     public const MULTI_SELECT_MENU_CHANNELS      = 'multi_channels_select';
@@ -78,7 +78,7 @@ abstract class Type
 
     public const ACCESSORY_ELEMENTS = [
         self::BUTTON,
-        // self::CHECKBOXES, // Not yet supported.
+        self::CHECKBOXES,
         self::DATEPICKER,
         self::IMAGE,
         self::MULTI_SELECT_MENU_CHANNELS,
@@ -87,7 +87,7 @@ abstract class Type
         self::MULTI_SELECT_MENU_STATIC,
         self::MULTI_SELECT_MENU_USERS,
         // self::OVERFLOW_MENU, // Not yet supported.
-        // self::RADIO_BUTTONS, // Not yet supported.
+        self::RADIO_BUTTONS,
         self::SELECT_MENU_CHANNELS,
         self::SELECT_MENU_CONVERSATIONS,
         self::SELECT_MENU_EXTERNAL,
@@ -98,10 +98,10 @@ abstract class Type
 
     public const ACTION_ELEMENTS = [
         self::BUTTON,
-        // self::CHECKBOXES, // Not yet supported.
+        self::CHECKBOXES,
         self::DATEPICKER,
         // self::OVERFLOW_MENU, // Not yet supported.
-        // self::RADIO_BUTTONS, // Not yet supported.
+        self::RADIO_BUTTONS,
         self::SELECT_MENU_CHANNELS,
         self::SELECT_MENU_CONVERSATIONS,
         self::SELECT_MENU_EXTERNAL,
@@ -113,14 +113,14 @@ abstract class Type
     public const CONTEXT_ELEMENTS = [self::IMAGE, self::MRKDWNTEXT, self::PLAINTEXT];
 
     public const INPUT_ELEMENTS = [
-        // self::CHECKBOXES, // Not yet supported.
+        self::CHECKBOXES,
         self::DATEPICKER,
         self::MULTI_SELECT_MENU_CHANNELS,
         self::MULTI_SELECT_MENU_CONVERSATIONS,
         self::MULTI_SELECT_MENU_EXTERNAL,
         self::MULTI_SELECT_MENU_STATIC,
         self::MULTI_SELECT_MENU_USERS,
-        // self::RADIO_BUTTONS, // Not yet supported.
+        self::RADIO_BUTTONS,
         self::SELECT_MENU_CHANNELS,
         self::SELECT_MENU_CONVERSATIONS,
         self::SELECT_MENU_EXTERNAL,
@@ -151,10 +151,10 @@ abstract class Type
 
         // Inputs
         Inputs\Button::class          => self::BUTTON,
-        // Inputs\Checkboxes::class   => self::CHECKBOXES, // Not yet supported.
+        Inputs\Checkboxes::class   => self::CHECKBOXES, // Not yet supported.
         Inputs\DatePicker::class      => self::DATEPICKER,
         // Inputs\OverflowMenu::class => self::OVERFLOW_MENU, // Not yet supported.
-        // Inputs\RadioButtons::class => self::RADIO_BUTTONS, // Not yet supported.
+        Inputs\RadioButtons::class => self::RADIO_BUTTONS,
         Inputs\TextInput::class       => self::TEXT_INPUT,
 
         // Select Menus

--- a/src/Type.php
+++ b/src/Type.php
@@ -28,7 +28,7 @@ abstract class Type
     public const DATEPICKER        = 'datepicker';
     public const TEXT_INPUT        = 'plain_text_input';
     // public const OVERFLOW_MENU  = 'overflow'; // Not yet supported.
-    public const RADIO_BUTTONS  = 'radio_buttons';
+    public const RADIO_BUTTONS     = 'radio_buttons';
 
     // Select Menus
     public const MULTI_SELECT_MENU_CHANNELS      = 'multi_channels_select';

--- a/tests/Inputs/CheckBoxesTest.php
+++ b/tests/Inputs/CheckBoxesTest.php
@@ -19,9 +19,9 @@ class CheckBoxesTest extends TestCase
     public function testCheckboxesWithConfirm()
     {
         $input = (new Checkboxes('checkboxes-identifier'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('bar', 'bar'), true)
-            ->addOption(new Option('foobar', 'foobar'), true)
+            ->option('foo', 'foo')
+            ->option('bar', 'bar', true)
+            ->option('foobar', 'foobar', true)
             ->setConfirm(new Confirm('Switch', 'Do you really want to switch?', 'Yes switch'));
 
         $this->assertJsonData([
@@ -92,17 +92,17 @@ class CheckBoxesTest extends TestCase
 
         $this->expectException(Exception::class);
         $input = (new Checkboxes())
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'));
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo');
         $input->validate();
     }
 

--- a/tests/Inputs/CheckBoxesTest.php
+++ b/tests/Inputs/CheckBoxesTest.php
@@ -112,5 +112,4 @@ class CheckBoxesTest extends TestCase
         $input = new Checkboxes();
         $input->validate();
     }
-
 }

--- a/tests/Inputs/CheckBoxesTest.php
+++ b/tests/Inputs/CheckBoxesTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jeremeamia\Slack\BlockKit\Tests\Inputs;
+
+use Jeremeamia\Slack\BlockKit\Exception;
+use Jeremeamia\Slack\BlockKit\Inputs\Checkboxes;
+use Jeremeamia\Slack\BlockKit\Partials\Confirm;
+use Jeremeamia\Slack\BlockKit\Partials\Option;
+use Jeremeamia\Slack\BlockKit\Tests\TestCase;
+use Jeremeamia\Slack\BlockKit\Type;
+
+/**
+ * @covers \Jeremeamia\Slack\BlockKit\Inputs\Checkboxes
+ */
+class CheckBoxesTest extends TestCase
+{
+    public function testCheckboxesWithConfirm()
+    {
+        $input = (new Checkboxes('checkboxes-identifier'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('bar', 'bar'), true)
+            ->addOption(new Option('foobar', 'foobar'), true)
+            ->setConfirm(new Confirm('Switch', 'Do you really want to switch?', 'Yes switch'));
+
+        $this->assertJsonData([
+            'type' => Type::CHECKBOXES,
+            'action_id' => 'checkboxes-identifier',
+            'initial_options' => [
+                [
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'bar',
+                    ],
+                    'value' => 'bar',
+                ],
+                [
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'foobar',
+                    ],
+                    'value' => 'foobar',
+                ]
+            ],
+            'options' => [
+                [
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'foo',
+                    ],
+                    'value' => 'foo',
+                ],
+                [
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'bar',
+                    ],
+                    'value' => 'bar',
+                ],
+                [
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'foobar',
+                    ],
+                    'value' => 'foobar',
+                ],
+            ],
+            'confirm' => [
+                'title' => [
+                    'type' => 'plain_text',
+                    'text' => 'Switch',
+                ],
+                'text' => [
+                    'type' => 'mrkdwn',
+                    'text' => 'Do you really want to switch?',
+                ],
+                'confirm' => [
+                    'type' => 'plain_text',
+                    'text' => 'Yes switch',
+                ],
+                'deny' => [
+                    'type' => 'plain_text',
+                    'text' => 'Cancel',
+                ],
+            ]
+        ], $input);
+    }
+
+    public function testTooManyOptions()
+    {
+
+        $this->expectException(Exception::class);
+        $input = (new Checkboxes())
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'));
+        $input->validate();
+    }
+
+    public function testNoOptions()
+    {
+        $this->expectException(Exception::class);
+        $input = new Checkboxes();
+        $input->validate();
+    }
+
+}

--- a/tests/Inputs/RadioButtonsTest.php
+++ b/tests/Inputs/RadioButtonsTest.php
@@ -19,9 +19,9 @@ class RadioButtonsTest extends TestCase
     public function testRadioButtonsWithConfirm()
     {
         $input = (new RadioButtons('radio-buttons-identifier'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('bar', 'bar'), true)
-            ->addOption(new Option('foobar', 'foobar'))
+            ->option('foo', 'foo')
+            ->option('bar', 'bar', true)
+            ->option('foobar', 'foobar')
             ->setConfirm(new Confirm('Switch', 'Do you really want to switch?', 'Yes switch'));
 
         $this->assertJsonData([
@@ -83,17 +83,17 @@ class RadioButtonsTest extends TestCase
 
         $this->expectException(Exception::class);
         $input = (new RadioButtons())
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'))
-            ->addOption(new Option('foo', 'foo'));
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo')
+            ->option('foo', 'foo');
         $input->validate();
     }
 

--- a/tests/Inputs/RadioButtonsTest.php
+++ b/tests/Inputs/RadioButtonsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jeremeamia\Slack\BlockKit\Tests\Inputs;
+
+use Jeremeamia\Slack\BlockKit\Exception;
+use Jeremeamia\Slack\BlockKit\Inputs\RadioButtons;
+use Jeremeamia\Slack\BlockKit\Partials\Confirm;
+use Jeremeamia\Slack\BlockKit\Partials\Option;
+use Jeremeamia\Slack\BlockKit\Tests\TestCase;
+use Jeremeamia\Slack\BlockKit\Type;
+
+/**
+ * @covers \Jeremeamia\Slack\BlockKit\Inputs\RadioButtons
+ */
+class RadioButtonsTest extends TestCase
+{
+    public function testRadioButtonsWithConfirm()
+    {
+        $input = (new RadioButtons('radio-buttons-identifier'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('bar', 'bar'), true)
+            ->addOption(new Option('foobar', 'foobar'))
+            ->setConfirm(new Confirm('Switch', 'Do you really want to switch?', 'Yes switch'));
+
+        $this->assertJsonData([
+            'type' => Type::RADIO_BUTTONS,
+            'action_id' => 'radio-buttons-identifier',
+            'initial_option' => [
+                'text' => [
+                    'type' => 'plain_text',
+                    'text' => 'bar',
+                ],
+                'value' => 'bar',
+            ],
+            'options' => [
+                [
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'foo',
+                    ],
+                    'value' => 'foo',
+                ],
+                [
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'bar',
+                    ],
+                    'value' => 'bar',
+                ],
+                [
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'foobar',
+                    ],
+                    'value' => 'foobar',
+                ],
+            ],
+            'confirm' => [
+                'title' => [
+                    'type' => 'plain_text',
+                    'text' => 'Switch',
+                ],
+                'text' => [
+                    'type' => 'mrkdwn',
+                    'text' => 'Do you really want to switch?',
+                ],
+                'confirm' => [
+                    'type' => 'plain_text',
+                    'text' => 'Yes switch',
+                ],
+                'deny' => [
+                    'type' => 'plain_text',
+                    'text' => 'Cancel',
+                ],
+            ]
+        ], $input);
+    }
+
+    public function testTooManyOptions()
+    {
+
+        $this->expectException(Exception::class);
+        $input = (new RadioButtons())
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'))
+            ->addOption(new Option('foo', 'foo'));
+        $input->validate();
+    }
+
+    public function testNoOptions()
+    {
+        $this->expectException(Exception::class);
+        $input = new RadioButtons();
+        $input->validate();
+    }
+
+}

--- a/tests/Inputs/RadioButtonsTest.php
+++ b/tests/Inputs/RadioButtonsTest.php
@@ -103,5 +103,4 @@ class RadioButtonsTest extends TestCase
         $input = new RadioButtons();
         $input->validate();
     }
-
 }

--- a/tests/manual/modal.php
+++ b/tests/manual/modal.php
@@ -29,16 +29,16 @@ $msg->newInput('c1')
 $msg->newInput('c2')
     ->label('Radio Buttons')
     ->newRadioButtons('radio_buttons')
-    ->addOption(new Option('foo', 'foo'))
-    ->addOption(new Option('bar', 'bar'), true)
-    ->addOption(new Option('foobar', 'foobar'))
+    ->option('foo', 'foo')
+    ->option('bar', 'bar', true)
+    ->option('foobar', 'foobar')
     ->setConfirm(new Confirm('Switch', 'Do you really want to switch?', 'Yes switch'));
 $msg->newInput('c3')
     ->label('Checkboxes')
     ->newCheckboxes('checkboxes')
-    ->addOption(new Option('foo', 'foo'))
-    ->addOption(new Option('bar', 'bar'), true)
-    ->addOption(new Option('foobar', 'foobar'), true)
+    ->option('foo', 'foo')
+    ->option('bar', 'bar', true)
+    ->option('foobar', 'foobar', true)
     ->setConfirm(new Confirm('Switch', 'Do you really want to switch?', 'Yes switch'));
 
 // echo Slack::newRenderer()->forJson()->render($msg) . "\n";

--- a/tests/manual/modal.php
+++ b/tests/manual/modal.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Jeremeamia\Slack\BlockKit\Partials\Confirm;
 use Jeremeamia\Slack\BlockKit\Slack;
+use Jeremeamia\Slack\BlockKit\Partials\Option;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
@@ -24,6 +26,20 @@ $msg->newInput('c1')
         ->multiline(true)
         ->minLength(10)
         ->maxLength(100);
+$msg->newInput('c2')
+    ->label('Radio Buttons')
+    ->newRadioButtons('radio_buttons')
+    ->addOption(new Option('foo', 'foo'))
+    ->addOption(new Option('bar', 'bar'), true)
+    ->addOption(new Option('foobar', 'foobar'))
+    ->setConfirm(new Confirm('Switch', 'Do you really want to switch?', 'Yes switch'));
+$msg->newInput('c3')
+    ->label('Checkboxes')
+    ->newCheckboxes('checkboxes')
+    ->addOption(new Option('foo', 'foo'))
+    ->addOption(new Option('bar', 'bar'), true)
+    ->addOption(new Option('foobar', 'foobar'), true)
+    ->setConfirm(new Confirm('Switch', 'Do you really want to switch?', 'Yes switch'));
 
 // echo Slack::newRenderer()->forJson()->render($msg) . "\n";
 echo Slack::newRenderer()->forKitBuilder()->render($msg) . "\n";


### PR DESCRIPTION
Hello, i have implmented 2 of the missing features, Radio Buttons and Checkboxes
Could you have a look and maybe aprove?

One notice: according to https://api.slack.com/reference/block-kit/interactive-components "Messages" can not have radios or checkboxes, this i have **not** validated anywhere.