### PR TITLE
Updates HasOptions to account for initialOptions

### DIFF
--- a/src/Inputs/Checkboxes.php
+++ b/src/Inputs/Checkboxes.php
@@ -4,33 +4,28 @@ declare(strict_types=1);
 
 namespace Jeremeamia\Slack\BlockKit\Inputs;
 
-use Jeremeamia\Slack\BlockKit\Exception;
-use Jeremeamia\Slack\BlockKit\Partials\HasOptions;
-use Jeremeamia\Slack\BlockKit\Partials\Option;
+use Jeremeamia\Slack\BlockKit\Partials\{HasOptions, OptionsConfig};
 
 class Checkboxes extends InputElement
 {
     use HasConfirm;
     use HasOptions;
 
-    private const MIN_OPTIONS = 1;
-    private const MAX_OPTIONS = 10;
+    protected function getOptionsConfig(): OptionsConfig
+    {
+        return OptionsConfig::new()
+            ->setMinOptions(1)
+            ->setMaxOptions(10)
+            ->setMaxInitialOptions(10);
+    }
 
     public function validate(): void
     {
-
         $this->validateOptions();
+        $this->validateInitialOptions();
 
         if (!empty($this->confirm)) {
             $this->confirm->validate();
-        }
-
-        if (count($this->options) > self::MAX_OPTIONS) {
-            throw new Exception('Option Size cannot exceed %d', [self::MAX_OPTIONS]);
-        }
-
-        if (count($this->options) < self::MIN_OPTIONS) {
-            throw new Exception('Option Size must be at least %d', [self::MIN_OPTIONS]);
         }
     }
 
@@ -39,15 +34,7 @@ class Checkboxes extends InputElement
      */
     public function toArray(): array
     {
-        $data = parent::toArray();
-
-        foreach ($this->options as $option) {
-            if ($option->isInitial()) {
-                $data['initial_options'][] = $option->toArray();
-            }
-        }
-
-        $data += $this->getOptionsAsArray();
+        $data = parent::toArray() + $this->getOptionsAsArray() + $this->getInitialOptionsAsArray();
 
         if (!empty($this->confirm)) {
             $data['confirm'] = $this->confirm->toArray();

--- a/src/Inputs/OverflowMenu.php
+++ b/src/Inputs/OverflowMenu.php
@@ -4,32 +4,38 @@ declare(strict_types=1);
 
 namespace Jeremeamia\Slack\BlockKit\Inputs;
 
-use Jeremeamia\Slack\BlockKit\Exception;
-use Jeremeamia\Slack\BlockKit\Partials\HasOptions;
+use Jeremeamia\Slack\BlockKit\Partials\{HasOptions, Option, OptionsConfig};
 
 class OverflowMenu extends InputElement
 {
     use HasConfirm;
     use HasOptions;
 
-    private const MIN_OPTIONS = 2;
-    private const MAX_OPTIONS = 5;
+    protected function getOptionsConfig(): OptionsConfig
+    {
+        return OptionsConfig::new()
+            ->setMinOptions(2)
+            ->setMaxOptions(5)
+            ->setMaxInitialOptions(0);
+    }
+
+    /**
+     * @param string $text
+     * @param string $value
+     * @param string $url
+     * @return static
+     */
+    public function urlOption(string $text, string $value, string $url): self
+    {
+        return $this->addOption(Option::new($text, $value)->url($url));
+    }
 
     public function validate(): void
     {
-
         $this->validateOptions();
 
         if (!empty($this->confirm)) {
             $this->confirm->validate();
-        }
-
-        if (count($this->options) > self::MAX_OPTIONS) {
-            throw new Exception('Option Size cannot exceed %d', [self::MAX_OPTIONS]);
-        }
-
-        if (count($this->options) < self::MIN_OPTIONS) {
-            throw new Exception('Option Size must be at least %d', [self::MIN_OPTIONS]);
         }
     }
 
@@ -38,8 +44,8 @@ class OverflowMenu extends InputElement
      */
     public function toArray(): array
     {
-
         $data = parent::toArray();
+
         $data += $this->getOptionsAsArray();
 
         if (!empty($this->confirm)) {

--- a/src/Inputs/RadioButtons.php
+++ b/src/Inputs/RadioButtons.php
@@ -4,46 +4,28 @@ declare(strict_types=1);
 
 namespace Jeremeamia\Slack\BlockKit\Inputs;
 
-use Jeremeamia\Slack\BlockKit\Exception;
-use Jeremeamia\Slack\BlockKit\Partials\HasOptions;
-use Jeremeamia\Slack\BlockKit\Partials\Option;
+use Jeremeamia\Slack\BlockKit\Partials\{HasOptions, OptionsConfig};
 
 class RadioButtons extends InputElement
 {
     use HasConfirm;
     use HasOptions;
 
-    private const MIN_OPTIONS = 1;
-    private const MAX_OPTIONS = 10;
+    protected function getOptionsConfig(): OptionsConfig
+    {
+        return OptionsConfig::new()
+            ->setMinOptions(1)
+            ->setMaxOptions(10)
+            ->setMaxInitialOptions(1);
+    }
 
     public function validate(): void
     {
-
         $this->validateOptions();
-
-        $hasInitial = false;
-
-        foreach ($this->options as $option) {
-            $option->validate();
-
-            if ($option->isInitial()) {
-                if ($hasInitial) {
-                    throw new Exception('Only one initial Option is allowed for Radio Buttons');
-                }
-                $hasInitial = true;
-            }
-        }
+        $this->validateInitialOptions();
 
         if (!empty($this->confirm)) {
             $this->confirm->validate();
-        }
-
-        if (count($this->options) > self::MAX_OPTIONS) {
-            throw new Exception('Option Size cannot exceed %d', [self::MAX_OPTIONS]);
-        }
-
-        if (count($this->options) < self::MIN_OPTIONS) {
-            throw new Exception('Option Size must be at least %d', [self::MIN_OPTIONS]);
         }
     }
 
@@ -52,16 +34,7 @@ class RadioButtons extends InputElement
      */
     public function toArray(): array
     {
-        $data = parent::toArray();
-
-        foreach ($this->options as $option) {
-            if ($option->isInitial()) {
-                $data['initial_option'] = $option->toArray();
-                break;
-            }
-        }
-
-        $data += $this->getOptionsAsArray();
+        $data = parent::toArray() + $this->getOptionsAsArray() + $this->getInitialOptionsAsArray();
 
         if (!empty($this->confirm)) {
             $data['confirm'] = $this->confirm->toArray();

--- a/src/Inputs/SelectMenus/ChannelSelectMenu.php
+++ b/src/Inputs/SelectMenus/ChannelSelectMenu.php
@@ -9,6 +9,9 @@ class ChannelSelectMenu extends SelectMenu
     /** @var string */
     private $initialChannel;
 
+    /** @var bool */
+    private $responseUrlEnabled;
+
     /**
      * @param string $initialChannel
      * @return static
@@ -16,6 +19,17 @@ class ChannelSelectMenu extends SelectMenu
     public function initialChannel(string $initialChannel): self
     {
         $this->initialChannel = $initialChannel;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $enabled
+     * @return static
+     */
+    public function responseUrlEnabled(bool $enabled): self
+    {
+        $this->responseUrlEnabled = $enabled;
 
         return $this;
     }
@@ -29,6 +43,10 @@ class ChannelSelectMenu extends SelectMenu
 
         if (!empty($this->initialChannel)) {
             $data['initial_channel'] = $this->initialChannel;
+        }
+
+        if (!empty($this->responseUrlEnabled)) {
+            $data['response_url_enabled'] = $this->responseUrlEnabled;
         }
 
         return $data;

--- a/src/Inputs/SelectMenus/ConversationSelectMenu.php
+++ b/src/Inputs/SelectMenus/ConversationSelectMenu.php
@@ -9,6 +9,12 @@ class ConversationSelectMenu extends SelectMenu
     /** @var string */
     private $initialConversation;
 
+    /** @var bool */
+    private $responseUrlEnabled;
+
+    /** @var bool */
+    private $defaultToCurrentConversation;
+
     /**
      * @param string $initialConversation
      * @return static
@@ -21,6 +27,30 @@ class ConversationSelectMenu extends SelectMenu
     }
 
     /**
+     * @param bool $enabled
+     * @return static
+     */
+    public function responseUrlEnabled(bool $enabled): self
+    {
+        $this->responseUrlEnabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $enabled
+     * @return static
+     */
+    public function defaultToCurrentConversation(bool $enabled): self
+    {
+        $this->defaultToCurrentConversation = $enabled;
+
+        return $this;
+    }
+
+    // @TODO: filter - https://api.slack.com/reference/block-kit/block-elements#conversation_select
+
+    /**
      * @return array
      */
     public function toArray(): array
@@ -29,6 +59,14 @@ class ConversationSelectMenu extends SelectMenu
 
         if (!empty($this->initialConversation)) {
             $data['initial_conversation'] = $this->initialConversation;
+        }
+
+        if (!empty($this->responseUrlEnabled)) {
+            $data['response_url_enabled'] = $this->responseUrlEnabled;
+        }
+
+        if (!empty($this->defaultToCurrentConversation)) {
+            $data['default_to_current_conversation'] = $this->defaultToCurrentConversation;
         }
 
         return $data;

--- a/src/Inputs/SelectMenus/ExternalSelectMenu.php
+++ b/src/Inputs/SelectMenus/ExternalSelectMenu.php
@@ -21,7 +21,7 @@ class ExternalSelectMenu extends SelectMenu
      */
     public function initialOption(string $name, string $value): self
     {
-        $this->initialOption = new Option($name, $value);
+        $this->initialOption = Option::new($name, $value);
         $this->initialOption->setParent($this);
 
         return $this;

--- a/src/Inputs/SelectMenus/MultiConversationSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiConversationSelectMenu.php
@@ -9,6 +9,9 @@ class MultiConversationSelectMenu extends MultiSelectMenu
     /** @var string[] */
     private $initialConversations;
 
+    /** @var bool */
+    private $defaultToCurrentConversation;
+
     /**
      * @param string[] $initialConversations
      * @return static
@@ -21,6 +24,19 @@ class MultiConversationSelectMenu extends MultiSelectMenu
     }
 
     /**
+     * @param bool $enabled
+     * @return static
+     */
+    public function defaultToCurrentConversation(bool $enabled): self
+    {
+        $this->defaultToCurrentConversation = $enabled;
+
+        return $this;
+    }
+
+    // @TODO: filter - https://api.slack.com/reference/block-kit/block-elements#conversation_select
+
+    /**
      * @return array
      */
     public function toArray(): array
@@ -29,6 +45,10 @@ class MultiConversationSelectMenu extends MultiSelectMenu
 
         if (!empty($this->initialConversations)) {
             $data['initial_conversations'] = $this->initialConversations;
+        }
+
+        if (!empty($this->defaultToCurrentConversation)) {
+            $data['default_to_current_conversation'] = $this->defaultToCurrentConversation;
         }
 
         return $data;

--- a/src/Inputs/SelectMenus/MultiExternalSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiExternalSelectMenu.php
@@ -21,7 +21,7 @@ class MultiExternalSelectMenu extends MultiSelectMenu
     public function initialOptions(array $options): self
     {
         foreach ($options as $name => $value) {
-            $option = new Option((string) $name, (string) $value);
+            $option = Option::new((string) $name, (string) $value);
             $option->setParent($this);
             $this->initialOptions[] = $option;
         }

--- a/src/Inputs/SelectMenus/MultiSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiSelectMenu.php
@@ -6,8 +6,8 @@ namespace Jeremeamia\Slack\BlockKit\Inputs\SelectMenus;
 
 abstract class MultiSelectMenu extends SelectMenu
 {
-    /** @var int */
-    private $maxSelectedItems;
+    /** @var int|null */
+    protected $maxSelectedItems;
 
     /**
      * @param int $maxSelectedItems

--- a/src/Inputs/SelectMenus/MultiStaticSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiStaticSelectMenu.php
@@ -4,55 +4,29 @@ declare(strict_types=1);
 
 namespace Jeremeamia\Slack\BlockKit\Inputs\SelectMenus;
 
-use Jeremeamia\Slack\BlockKit\Partials\HasOptionGroups;
-use Jeremeamia\Slack\BlockKit\Partials\Option;
+use Jeremeamia\Slack\BlockKit\Partials\{HasOptionGroups, OptionsConfig};
 
 class MultiStaticSelectMenu extends MultiSelectMenu
 {
     use HasOptionGroups;
 
-    /** @var Option[] */
-    private $initialOptions;
-
-    /**
-     * @param array $options
-     * @return self
-     */
-    public function initialOptions(array $options): self
+    protected function getOptionsConfig(): OptionsConfig
     {
-        foreach ($options as $name => $value) {
-            $option = new Option((string) $name, (string) $value);
-            $option->setParent($this);
-            $this->initialOptions[] = $option;
-        }
-
-        return $this;
+        return OptionsConfig::new()
+            ->setMinOptions(1)
+            ->setMaxOptions(100)
+            ->setMaxInitialOptions($this->maxSelectedItems ?? null);
     }
 
     public function validate(): void
     {
         parent::validate();
-
         $this->validateOptionGroups();
-
-        if (!empty($this->initialOptions)) {
-            foreach ($this->initialOptions as $option) {
-                $option->validate();
-            }
-        }
+        $this->validateInitialOptions();
     }
 
     public function toArray(): array
     {
-        $data = parent::toArray();
-        $data += $this->getOptionGroupsAsArray();
-
-        if (!empty($this->initialOptions)) {
-            $data['initial_options'] = array_map(function (Option $option) {
-                return $option->toArray();
-            }, $this->initialOptions);
-        }
-
-        return $data;
+        return parent::toArray() + $this->getOptionGroupsAsArray() + $this->getInitialOptionsAsArray();
     }
 }

--- a/src/Inputs/SelectMenus/StaticSelectMenu.php
+++ b/src/Inputs/SelectMenus/StaticSelectMenu.php
@@ -4,27 +4,18 @@ declare(strict_types=1);
 
 namespace Jeremeamia\Slack\BlockKit\Inputs\SelectMenus;
 
-use Jeremeamia\Slack\BlockKit\Partials\HasOptionGroups;
-use Jeremeamia\Slack\BlockKit\Partials\Option;
+use Jeremeamia\Slack\BlockKit\Partials\{HasOptionGroups, OptionsConfig};
 
 class StaticSelectMenu extends SelectMenu
 {
     use HasOptionGroups;
 
-    /** @var Option */
-    private $initialOption;
-
-    /**
-     * @param string $name
-     * @param string $value
-     * @return self
-     */
-    public function initialOption(string $name, string $value): self
+    protected function getOptionsConfig(): OptionsConfig
     {
-        $this->initialOption = new Option($name, $value);
-        $this->initialOption->setParent($this);
-
-        return $this;
+        return OptionsConfig::new()
+            ->setMinOptions(1)
+            ->setMaxOptions(100)
+            ->setMaxInitialOptions(1);
     }
 
     public function validate(): void
@@ -32,21 +23,13 @@ class StaticSelectMenu extends SelectMenu
         parent::validate();
 
         $this->validateOptionGroups();
-
-        if (!empty($this->initialOption)) {
-            $this->initialOption->validate();
-        }
+        $this->validateInitialOptions();
     }
 
     public function toArray(): array
     {
-        $data = parent::toArray();
-        $data += $this->getOptionGroupsAsArray();
-
-        if (!empty($this->initialOption)) {
-            $data['initial_option'] = $this->initialOption->toArray();
-        }
-
-        return $data;
+        return parent::toArray()
+            + $this->getOptionGroupsAsArray()
+            + $this->getInitialOptionsAsArray();
     }
 }

--- a/src/Partials/HasOptionGroups.php
+++ b/src/Partials/HasOptionGroups.php
@@ -33,7 +33,7 @@ trait HasOptionGroups
      */
     public function optionGroup(string $label, array $options): self
     {
-        $group = new OptionGroup($label, $options);
+        $group = OptionGroup::new($label, $options);
         $group->setParent($this);
         $this->optionGroups[] = $group;
 

--- a/src/Partials/HasOptions.php
+++ b/src/Partials/HasOptions.php
@@ -9,16 +9,59 @@ use Jeremeamia\Slack\BlockKit\Exception;
 trait HasOptions
 {
     /** @var Option[]|array */
-    private $options;
+    private $options = [];
+
+    /** @var Option[]|array */
+    private $initialOptions = [];
+
+    /** @var OptionsConfig|null */
+    private $config;
 
     /**
-     * @param array $options
+     * @return OptionsConfig
+     */
+    private function config(): OptionsConfig
+    {
+        if (!$this->config) {
+            $this->config = $this->getOptionsConfig();
+        }
+
+        return $this->config;
+    }
+
+    /**
+     * @return OptionsConfig
+     */
+    protected function getOptionsConfig(): OptionsConfig
+    {
+        return new OptionsConfig();
+    }
+
+    /**
+     * @param Option $option
+     * @param bool $isInitial
      * @return static
      */
-    public function options(array $options): self
+    public function addOption(Option $option, bool $isInitial = false): self
     {
-        foreach ($options as $text => $value) {
-            $this->option((string) $text, (string) $value);
+        $option->setParent($this);
+        $this->options[] = $option;
+
+        if ($isInitial) {
+            $this->initialOptions[] = $option;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param Option[] $options
+     * @return static
+     */
+    public function addOptions(array $options): self
+    {
+        foreach ($options as $option) {
+            $this->addOption($option);
         }
 
         return $this;
@@ -32,21 +75,91 @@ trait HasOptions
      */
     public function option(string $text, string $value, bool $isInitial = false): self
     {
-        $option = new Option($text, $value, $isInitial);
-        $option->setParent($this);
-        $this->options[] = $option;
+        return $this->addOption(Option::new($text, $value), $isInitial);
+    }
+
+    /**
+     * @param array|string[] $options
+     * @return static
+     */
+    public function options(array $options): self
+    {
+        foreach ($options as $text => $value) {
+            $this->addOption(Option::new((string) $text, (string) $value));
+        }
 
         return $this;
     }
 
-    protected function validateOptions()
+    /**
+     * @param string $name
+     * @param string $value
+     * @return self
+     */
+    public function initialOption(string $name, string $value): self
     {
-        if (empty($this->options)) {
-            throw new Exception('You must provide "options".');
+        $initialOption = Option::new($name, $value);
+        $initialOption->setParent($this);
+        $this->initialOptions[] = $initialOption;
+
+        return $this;
+    }
+
+    /**
+     * @param array $options
+     * @return self
+     */
+    public function initialOptions(array $options): self
+    {
+        foreach ($options as $name => $value) {
+            $this->initialOption((string) $name, (string) $value);
+        }
+
+        return $this;
+    }
+
+    protected function validateOptions(): void
+    {
+        $minOptions = (int) $this->config()->getMinOptions();
+        if (empty($this->options) || count($this->options) < $minOptions) {
+            throw new Exception('You must provide at least %d "options" for %s.', [$minOptions, static::class]);
+        }
+
+        $maxOptions = $this->config()->getMaxOptions();
+        if ($maxOptions !== null && count($this->options) > $maxOptions) {
+            throw new Exception('You must not provide more than %d "options" for %s.', [$maxOptions, static::class]);
         }
 
         foreach ($this->options as $option) {
             $option->validate();
+        }
+
+        $maxInitialOptions = $this->config()->getMaxInitialOptions();
+        if ($maxInitialOptions !== null && count($this->initialOptions) > $maxInitialOptions) {
+            throw new Exception(
+                'You must not provide more than %d "initial_options" for %s.',
+                [$maxInitialOptions, static::class]
+            );
+        }
+
+        foreach ($this->initialOptions as $initialOption) {
+            $initialOption->validate();
+        }
+    }
+
+    protected function validateInitialOptions(): void
+    {
+        $maxInitialOptions = $this->config()->getMaxInitialOptions();
+
+        if ($maxInitialOptions !== null && count($this->initialOptions) > $maxInitialOptions) {
+            throw new Exception(
+                'You must not provide more than %d "initial_options" for %s.',
+                [$maxInitialOptions, static::class]
+            );
+        }
+
+        foreach ($this->initialOptions as $initialOption) {
+            $initialOption->validate();
         }
     }
 
@@ -55,5 +168,22 @@ trait HasOptions
         return ['options' => array_map(function (Option $option) {
             return $option->toArray();
         }, $this->options)];
+    }
+
+    protected function getInitialOptionsAsArray(): array
+    {
+        if (empty($this->initialOptions)) {
+            return [];
+        }
+
+        $maxInitialOptions = (int) $this->config()->getMaxInitialOptions();
+
+        if ($maxInitialOptions === 1) {
+            return ['initial_option' => $this->initialOptions[0]->toArray()];
+        }
+
+        return ['initial_options' => array_map(function (Option $initialOption) {
+            return $initialOption->toArray();
+        }, $this->initialOptions)];
     }
 }

--- a/src/Partials/OptionGroup.php
+++ b/src/Partials/OptionGroup.php
@@ -13,15 +13,29 @@ class OptionGroup extends Element
     /** @var PlainText */
     private $label;
 
-    public function __construct(?string $label = null, array $options = [])
+    /**
+     * @param string|null $label
+     * @param array|null $options
+     * @return OptionGroup
+     */
+    public static function new(?string $label = null, ?array $options = null): self
     {
+        $optionGroup = new self();
+
         if ($label !== null) {
-            $this->label($label);
+            $optionGroup->label($label);
         }
 
-        if (!empty($options)) {
-            $this->options($options);
+        if ($options !== null) {
+            $optionGroup->options($options);
         }
+
+        return $optionGroup;
+    }
+
+    protected function getOptionsConfig(): OptionsConfig
+    {
+        return OptionsConfig::new()->setMinOptions(1)->setMaxOptions(100);
     }
 
     /**

--- a/src/Partials/OptionsConfig.php
+++ b/src/Partials/OptionsConfig.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jeremeamia\Slack\BlockKit\Partials;
+
+class OptionsConfig
+{
+    /** @var int|null Minimum number of options supported. */
+    private $minOptions;
+
+    /** @var int|null Maximum number of options supported. */
+    private $maxOptions;
+
+    /** @var int|null Maximum number of initial options supported. */
+    private $maxInitialOptions;
+
+    public static function new(): self
+    {
+        return new self();
+    }
+
+    public function __construct()
+    {
+        $this->minOptions = 1;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMinOptions(): ?int
+    {
+        return $this->minOptions;
+    }
+
+    /**
+     * @param int|null $minOptions
+     * @return self
+     */
+    public function setMinOptions(?int $minOptions): self
+    {
+        $this->minOptions = $minOptions;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMaxOptions(): ?int
+    {
+        return $this->maxOptions;
+    }
+
+    /**
+     * @param int|null $maxOptions
+     * @return self
+     */
+    public function setMaxOptions(?int $maxOptions): self
+    {
+        $this->maxOptions = $maxOptions;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMaxInitialOptions(): ?int
+    {
+        return $this->maxInitialOptions;
+    }
+
+    /**
+     * @param int|null $maxInitialOptions
+     * @return self
+     */
+    public function setMaxInitialOptions(?int $maxInitialOptions): self
+    {
+        $this->maxInitialOptions = $maxInitialOptions;
+
+        return $this;
+    }
+}

--- a/src/Partials/Text.php
+++ b/src/Partials/Text.php
@@ -24,7 +24,7 @@ abstract class Text extends Element
 
     public function validate(): void
     {
-        $this->validateWithLength();
+        self::validateString($this->text);
     }
 
     /**
@@ -35,15 +35,27 @@ abstract class Text extends Element
      */
     public function validateWithLength(?int $max = null, int $min = 0): void
     {
-        if (!is_string($this->text)) {
+        self::validateString($this->text, $max, $min);
+    }
+
+    /**
+     * Validate string length for textual element properties.
+     *
+     * @param string $text String to validate.
+     * @param int|null $max Max length, or null if it doesn't have a max.
+     * @param int $min Min length, defaults to 0.
+     */
+    public static function validateString(string $text, ?int $max = null, int $min = 0): void
+    {
+        if (!is_string($text)) {
             throw new Exception('Text element must have a "text" value');
         }
 
-        if (strlen($this->text) < $min) {
+        if (strlen($text) < $min) {
             throw new Exception('Text element must have a "text" value with a length of at least %d', [$min]);
         }
 
-        if (is_int($max) && strlen($this->text) > $max) {
+        if (is_int($max) && strlen($text) > $max) {
             throw new Exception('Text element must have a "text" value with a length of at most %d', [$max]);
         }
     }

--- a/src/Surfaces/AppHome.php
+++ b/src/Surfaces/AppHome.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Jeremeamia\Slack\BlockKit\Surfaces;
 
+/**
+ * The App Home tab is a persistent, yet dynamic interface for apps that lives within the App Home for a user.
+ *
+ * @see https://api.slack.com/surfaces
+ */
 class AppHome extends Surface
 {
     // Nothing special.

--- a/src/Surfaces/Message.php
+++ b/src/Surfaces/Message.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Jeremeamia\Slack\BlockKit\Surfaces;
 
+/**
+ * App-published messages are dynamic yet transient spaces. They allow users to complete workflows among their
+ * Slack conversations.
+ *
+ * @see https://api.slack.com/surfaces
+ */
 class Message extends Surface
 {
     public const EPHEMERAL = 'ephemeral';

--- a/src/Surfaces/Modal.php
+++ b/src/Surfaces/Modal.php
@@ -6,6 +6,12 @@ namespace Jeremeamia\Slack\BlockKit\Surfaces;
 
 use Jeremeamia\Slack\BlockKit\{Blocks\Input, Exception, Partials\PlainText, Type};
 
+/**
+ * Modals provide focused spaces ideal for requesting and collecting data from users, or temporarily displaying dynamic
+ * and interactive information.
+ *
+ * @see https://api.slack.com/surfaces
+ */
 class Modal extends Surface
 {
     private const MAX_LENGTH_TITLE = 24;

--- a/tests/ElementTest.php
+++ b/tests/ElementTest.php
@@ -42,6 +42,27 @@ class ElementTest extends TestCase
         $this->assertInstanceOf(Section::class, $element);
     }
 
+    public function testCanSetExtraFieldsForArbitraryData()
+    {
+        $element = $this->getMockElement();
+
+        $element->setExtra('fizz', 'buzz');
+
+        $this->assertJsonData($element, [
+            'type' => 'mock',
+            'text' => 'foo',
+            'fizz' => 'buzz',
+        ]);
+    }
+
+    public function testErrorIfExtraFieldIsInvalid()
+    {
+        $element = $this->getMockElement();
+
+        $this->expectException(Exception::class);
+        $element->setExtra('fizz', new \SplQueue());
+    }
+
     private function getMockElement(bool $valid = true): Element
     {
         return new class ($valid) extends Element {

--- a/tests/Inputs/CheckBoxesTest.php
+++ b/tests/Inputs/CheckBoxesTest.php
@@ -7,7 +7,6 @@ namespace Jeremeamia\Slack\BlockKit\Tests\Inputs;
 use Jeremeamia\Slack\BlockKit\Exception;
 use Jeremeamia\Slack\BlockKit\Inputs\Checkboxes;
 use Jeremeamia\Slack\BlockKit\Partials\Confirm;
-use Jeremeamia\Slack\BlockKit\Partials\Option;
 use Jeremeamia\Slack\BlockKit\Tests\TestCase;
 use Jeremeamia\Slack\BlockKit\Type;
 

--- a/tests/Inputs/OverflowMenuTest.php
+++ b/tests/Inputs/OverflowMenuTest.php
@@ -19,7 +19,7 @@ class OverflowMenuTest extends TestCase
     {
         $input = (new OverflowMenu('overflow-identifier'))
             ->option('foo', 'foo')
-            ->option('bar', 'bar')
+            ->urlOption('bar', 'bar', 'https://example.org')
             ->option('foobar', 'foobar')
             ->setConfirm(new Confirm('Choose', 'Do you really want to choose this?', 'Yes choose'));
 
@@ -40,6 +40,7 @@ class OverflowMenuTest extends TestCase
                         'text' => 'bar',
                     ],
                     'value' => 'bar',
+                    'url' => 'https://example.org'
                 ],
                 [
                     'text' => [

--- a/tests/Inputs/RadioButtonsTest.php
+++ b/tests/Inputs/RadioButtonsTest.php
@@ -7,7 +7,6 @@ namespace Jeremeamia\Slack\BlockKit\Tests\Inputs;
 use Jeremeamia\Slack\BlockKit\Exception;
 use Jeremeamia\Slack\BlockKit\Inputs\RadioButtons;
 use Jeremeamia\Slack\BlockKit\Partials\Confirm;
-use Jeremeamia\Slack\BlockKit\Partials\Option;
 use Jeremeamia\Slack\BlockKit\Tests\TestCase;
 use Jeremeamia\Slack\BlockKit\Type;
 

--- a/tests/manual/menus.php
+++ b/tests/manual/menus.php
@@ -25,9 +25,8 @@ $msg->newActions('b2')
         ->forStaticOptions()
         ->placeholder('Choose a letter?')
         ->option('a', 'x')
-        ->option('b', 'y')
-        ->option('c', 'z')
-        ->initialOption('b', 'y');
+        ->option('b', 'y', true)
+        ->option('c', 'z');
 $msg->newActions('b3')
     ->newSelectMenu('m4')
         ->forStaticOptions()
@@ -68,7 +67,7 @@ $msg->newSection('b5')
     ->mrkdwnText('Select from Overflow Menu')
     ->newOverflowMenuAccessory('m6')
     ->option('foo', 'foo')
-    ->option('bar', 'bar')
+    ->urlOption('bar', 'bar', 'https://example.org')
     ->option('foobar', 'foobar')
     ->setConfirm(new Confirm('Choose', 'Do you really want to choose this?', 'Yes choose'));
 //echo Slack::newRenderer()->forJson()->render($msg) . "\n";


### PR DESCRIPTION
Updates `HasOptions` to account for `initialOption(s)`, including providing validation and array-ifying helpers. Introduces `OptionsConfig` as a way to parameterize `HasOptions` behaviors. Also, updates all `HasOptions`/`HasOptionGroups`-using elements. Breaks `isInitial` back out from the `Option` as a separately-managed thing.

In addition, adds `setExtra` to base `Element` object to allow for patching on new Slack features in a non-conflicting way prior to the library being updated. Also, updates some other menus with new/missing parameters.