### PR TITLE
Added support for Message Attachments.

### DIFF
--- a/src/Surfaces/Attachment.php
+++ b/src/Surfaces/Attachment.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jeremeamia\Slack\BlockKit\Surfaces;
+
+use Jeremeamia\Slack\BlockKit\Element;
+
+/**
+ * Attachments are a surface that represent secondary content within a message, and can only exist within a message.
+ *
+ * Messages can add one or more attachments that have their own set of blocks.
+ *
+ * Attachments have other legacy attributes besides "color", but their use is discouraged. You can accomplish all of the
+ * same things using blocks. If you want to set the legacy attributes, you can use `setExtra()`, inherited from Element.
+ *
+ * @see Element::setExtra()
+ * @see https://api.slack.com/messaging/composing/layouts#attachments
+ */
+class Attachment extends Surface
+{
+    /** @var string */
+    private $color;
+
+    /**
+     * Sets the hex color of the attachment. It Appears as a border along the left side.
+     *
+     * This makes sure the `#` is included in the color, in case you forget it.
+     *
+     * @param string $color
+     * @return Attachment
+     */
+    public function color(string $color): self
+    {
+        $this->color = '#' . ltrim($color, '#');
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+
+        if (!empty($this->color)) {
+            $data['color'] = $this->color;
+        }
+
+        return $data;
+    }
+}

--- a/src/Surfaces/Message.php
+++ b/src/Surfaces/Message.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Jeremeamia\Slack\BlockKit\Surfaces;
 
+use Jeremeamia\Slack\BlockKit\Exception;
+
 /**
  * App-published messages are dynamic yet transient spaces. They allow users to complete workflows among their
  * Slack conversations.
@@ -20,10 +22,13 @@ class Message extends Surface
     /** @var array|string[] A message can have a directive (e.g., response_type) included along with its blocks. */
     private $directives = [];
 
+    /** @var array|Attachment[] Attachments containing secondary content. */
+    private $attachments = [];
+
     /**
      * Configures message to send to the entire channel.
      *
-     * @return Message
+     * @return static
      */
     public function inChannel(): self
     {
@@ -37,7 +42,7 @@ class Message extends Surface
      *
      * This is default behavior for most interactions, and doesn't necessarily need to be explicitly configured.
      *
-     * @return Message
+     * @return static
      */
     public function ephemeral(): self
     {
@@ -49,7 +54,7 @@ class Message extends Surface
     /**
      * Configures message to "replace_original" mode.
      *
-     * @return Message
+     * @return static
      */
     public function replaceOriginal(): self
     {
@@ -61,7 +66,7 @@ class Message extends Surface
     /**
      * Configures message to "delete_original" mode.
      *
-     * @return Message
+     * @return static
      */
     public function deleteOriginal(): self
     {
@@ -70,8 +75,59 @@ class Message extends Surface
         return $this;
     }
 
+    /**
+     * @param Attachment $attachment
+     * @return static
+     */
+    public function addAttachment(Attachment $attachment): self
+    {
+        $this->attachments[] = $attachment->setParent($this);
+
+        return $this;
+    }
+
+    /**
+     * @return Attachment
+     */
+    public function newAttachment(): Attachment
+    {
+        $attachment = new Attachment();
+        $this->addAttachment($attachment);
+
+        return $attachment;
+    }
+
+    public function validate(): void
+    {
+        $hasBlocks = !empty($this->getBlocks());
+        if ($hasBlocks) {
+            parent::validate();
+        }
+
+        if (!$hasBlocks && empty($this->attachments)) {
+            throw new Exception('A message must contain blocks and/or attachments');
+        }
+
+        foreach ($this->attachments as $attachment) {
+            $attachment->validate();
+        }
+    }
+
     public function toArray(): array
     {
-        return $this->directives + parent::toArray();
+        $data = $this->directives + parent::toArray();
+
+        if ($this->attachments) {
+            $data['attachments'] = [];
+            foreach ($this->attachments as $attachment) {
+                $data['attachments'][] = $attachment->toArray();
+            }
+        }
+
+        if (empty($data['blocks'])) {
+            unset($data['blocks']);
+        }
+
+        return $data;
     }
 }

--- a/src/Surfaces/Surface.php
+++ b/src/Surfaces/Surface.php
@@ -17,8 +17,6 @@ use Jeremeamia\Slack\BlockKit\{Exception, Element, Type};
 
 /**
  * A Slack app surface is something within a Slack app that renders blocks from the block kit (e.g., a Message).
- *
- * There are currently three kinds of app surfaces: Message, Model, AppHome.
  */
 abstract class Surface extends Element
 {

--- a/src/Type.php
+++ b/src/Type.php
@@ -10,6 +10,7 @@ abstract class Type
 {
     // Surfaces
     public const APPHOME       = 'home';
+    public const ATTACHMENT    = 'attachment';
     public const MESSAGE       = 'message';
     public const MODAL         = 'modal';
     public const WORKFLOW_STEP = 'workflow_step';
@@ -57,6 +58,14 @@ abstract class Type
             self::ACTIONS,
             self::CONTEXT,
             self::DIVIDER,
+            self::IMAGE,
+            self::SECTION,
+        ],
+        self::ATTACHMENT => [
+            self::ACTIONS,
+            self::CONTEXT,
+            self::DIVIDER,
+            // self::FILE, // Not yet supported.
             self::IMAGE,
             self::SECTION,
         ],
@@ -142,11 +151,19 @@ abstract class Type
         self::TIMEPICKER,
     ];
 
-    public const HIDDEN_TYPES = [self::MESSAGE, self::FIELDS, self::CONFIRM, self::OPTION, self::OPTION_GROUP];
+    public const HIDDEN_TYPES = [
+        self::ATTACHMENT,
+        self::CONFIRM,
+        self::FIELDS,
+        self::MESSAGE,
+        self::OPTION,
+        self::OPTION_GROUP,
+    ];
 
     private static $typeMap = [
         // Surfaces
         Surfaces\AppHome::class      => self::APPHOME,
+        Surfaces\Attachment::class   => self::ATTACHMENT,
         Surfaces\Message::class      => self::MESSAGE,
         Surfaces\Modal::class        => self::MODAL,
         Surfaces\WorkflowStep::class => self::WORKFLOW_STEP,

--- a/tests/Surfaces/AttachmentTest.php
+++ b/tests/Surfaces/AttachmentTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jeremeamia\Slack\BlockKit\Tests\Surfaces;
+
+use Jeremeamia\Slack\BlockKit\Surfaces\Attachment;
+use Jeremeamia\Slack\BlockKit\Tests\TestCase;
+use Jeremeamia\Slack\BlockKit\Type;
+
+/**
+ * @covers \Jeremeamia\Slack\BlockKit\Surfaces\Attachment
+ */
+class AttachmentTest extends TestCase
+{
+    public function testCanCreateAttachment()
+    {
+        $msg = Attachment::new()->color('00ff00')->text('foo');
+
+        $this->assertJsonData([
+            'color' => '#00ff00',
+            'blocks' => [
+                [
+                    'type' => Type::SECTION,
+                    'text' => [
+                        'type' => Type::MRKDWNTEXT,
+                        'text' => 'foo',
+                    ],
+                ],
+            ],
+        ], $msg);
+    }
+}

--- a/tests/Surfaces/MessageTest.php
+++ b/tests/Surfaces/MessageTest.php
@@ -4,44 +4,152 @@ declare(strict_types=1);
 
 namespace Jeremeamia\Slack\BlockKit\Tests\Surfaces;
 
+use Jeremeamia\Slack\BlockKit\Exception;
 use Jeremeamia\Slack\BlockKit\Surfaces\Message;
 use Jeremeamia\Slack\BlockKit\Tests\TestCase;
+use Jeremeamia\Slack\BlockKit\Type;
 
 /**
  * @covers \Jeremeamia\Slack\BlockKit\Surfaces\Message
  */
 class MessageTest extends TestCase
 {
-    /**
-     * @param Message $message
-     * @param string $directiveKey
-     * @param string $directiveValue
-     * @dataProvider provideDirectivesUseCases
-     */
-    public function testCanApplyDirectives(Message $message, string $directiveKey, string $directiveValue)
+    private const TEST_BLOCKS = [
+        [
+            'type' => Type::SECTION,
+            'text' => [
+                'type' => Type::MRKDWNTEXT,
+                'text' => 'foo',
+            ],
+        ],
+    ];
+
+    public function testCanApplyEphemeralDirectives()
     {
-        $data = $message->text('foo')->toArray();
+        $data = Message::new()->ephemeral()->text('foo')->toArray();
         $this->assertArrayHasKey('blocks', $data);
-        $this->assertArrayHasKey($directiveKey, $data);
-        $this->assertEquals($directiveValue, $data[$directiveKey]);
+        $this->assertArrayHasKey('response_type', $data);
+        $this->assertEquals('ephemeral', $data['response_type']);
+
+        $msg = Message::new()->ephemeral()->text('foo');
+        $this->assertJsonData([
+            'response_type' => 'ephemeral',
+            'blocks' => self::TEST_BLOCKS,
+        ], $msg);
     }
 
-    public function provideDirectivesUseCases()
+    public function testCanApplyInChannelDirectives()
     {
-        return [
-            [Message::new()->ephemeral(), 'response_type', 'ephemeral'],
-            [Message::new()->inChannel(), 'response_type', 'in_channel'],
-            [Message::new()->replaceOriginal(), 'replace_original', 'true'],
-            [Message::new()->deleteOriginal(), 'delete_original', 'true'],
-        ];
+        $msg = Message::new()->inChannel()->text('foo');
+        $this->assertJsonData([
+            'response_type' => 'in_channel',
+            'blocks' => self::TEST_BLOCKS,
+        ], $msg);
+    }
+
+    public function testCanApplyReplaceOriginalDirectives()
+    {
+        $msg = Message::new()->replaceOriginal()->text('foo');
+        $this->assertJsonData([
+            'replace_original' => 'true',
+            'blocks' => self::TEST_BLOCKS,
+        ], $msg);
+    }
+
+    public function testCanApplyDeleteOriginalDirectives()
+    {
+        $msg = Message::new()->deleteOriginal()->text('foo');
+        $this->assertJsonData([
+            'delete_original' => 'true',
+            'blocks' => self::TEST_BLOCKS,
+        ], $msg);
+    }
+
+    public function testCanOnlyApplyOneDirective()
+    {
+        $msg = Message::new()
+            ->text('foo')
+            ->ephemeral()
+            ->replaceOriginal()
+            ->deleteOriginal();
+
+        $this->assertJsonData([
+            'delete_original' => 'true',
+            'blocks' => self::TEST_BLOCKS,
+        ], $msg);
     }
 
     public function testDoesNotApplyDirectivesWhenNotSet()
     {
         $data = Message::new()->text('foo')->toArray();
-        $this->assertArrayHasKey('blocks', $data);
         $this->assertArrayNotHasKey('response_type', $data);
         $this->assertArrayNotHasKey('replace_original', $data);
         $this->assertArrayNotHasKey('delete_original', $data);
+    }
+
+    public function testCanAddAttachments()
+    {
+        $msg = Message::new()->tap(function (Message $msg) {
+            $msg->text('foo');
+            $msg->newAttachment()->text('bar');
+            $msg->newAttachment()->text('baz');
+        });
+
+        $this->assertJsonData([
+            'blocks' => [
+                [
+                    'type' => Type::SECTION,
+                    'text' => [
+                        'type' => Type::MRKDWNTEXT,
+                        'text' => 'foo',
+                    ],
+                ],
+            ],
+            'attachments' => [
+                [
+                    'blocks' => [
+                        [
+                            'type' => Type::SECTION,
+                            'text' => [
+                                'type' => Type::MRKDWNTEXT,
+                                'text' => 'bar',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'blocks' => [
+                        [
+                            'type' => Type::SECTION,
+                            'text' => [
+                                'type' => Type::MRKDWNTEXT,
+                                'text' => 'baz',
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        ], $msg);
+    }
+
+    public function testCanAddAttachmentsWithoutPrimaryBlocks()
+    {
+        $msg = Message::new()->tap(function (Message $msg) {
+            $msg->newAttachment()->text('foo');
+        });
+
+        $this->assertJsonData([
+            'attachments' => [
+                [
+                    'blocks' => self::TEST_BLOCKS,
+                ],
+            ]
+        ], $msg);
+    }
+
+    public function testMustAddBlocksAndOrAttachments()
+    {
+        $this->expectException(Exception::class);
+        Message::new()->validate();
     }
 }

--- a/tests/manual/attachments.php
+++ b/tests/manual/attachments.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Jeremeamia\Slack\BlockKit\Slack;
+use Jeremeamia\Slack\BlockKit\Surfaces\Message;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$msg = Message::new()->tap(function (Message $msg) {
+    $msg->text('Primary Content');
+    $msg->newAttachment()->color('#ff0000')->text('Attachment 1');
+    $msg->newAttachment()->color('#00ff00')->text('Attachment 2');
+    $msg->newAttachment()->color('#0000ff')->text('Attachment 3');
+});
+
+//echo Slack::newRenderer()->forJson()->render($msg) . "\n";
+echo Slack::newRenderer()->forKitBuilder()->render($msg) . "\n";
+// echo Slack::newRenderer()->forCli()->render($msg) . "\n";


### PR DESCRIPTION
Added support for Message Attachments. An `Attachment` is a new surface and support all blocks that a message supports.
```php
$message->newAttachment()->color('#00ff00')->text('Hello!');
```

This PR fixes #8 and replaces #9.

See https://api.slack.com/messaging/composing/layouts#attachments

Note: Also changed `KitRenderer` to use the updated Block Kit Builder URL.

Note: Block Kit Builder does not render messages with blocks AND attachments or messages with _multiple_ attachments correctly, but real Slack apps do.